### PR TITLE
Fix bug upload image from clipboard

### DIFF
--- a/admin/src/components/editorjs/requiredTools.js
+++ b/admin/src/components/editorjs/requiredTools.js
@@ -1,5 +1,6 @@
 import PluginId from '../../pluginId'
 const axios = require('axios')
+import { auth } from '@strapi/helper-plugin';
 
 // Plugins for Editor.js
 import Image from '@editorjs/image'
@@ -13,7 +14,7 @@ const requiredTools = {
         data: JSON.stringify({})
       },
       additionalRequestHeaders: {
-        "Authorization": `Bearer ${JSON.parse(sessionStorage.getItem("jwtToken"))}`
+        "Authorization": `Bearer ${auth.getToken()}`
       },
       endpoints: {
         byUrl: `/api/${PluginId}/image/byUrl`,
@@ -26,7 +27,7 @@ const requiredTools = {
 
           const {data} = await axios.post(`/api/${PluginId}/image/byFile`, formData, {
             headers: {
-              "Authorization": `Bearer ${JSON.parse(sessionStorage.getItem("jwtToken"))}`
+              "Authorization": `Bearer ${auth.getToken()}`
             }
           });
 

--- a/admin/src/pluginId.js
+++ b/admin/src/pluginId.js
@@ -1,6 +1,6 @@
 const pluginPkg = require('../../package.json');
 const pluginId = pluginPkg.name.replace(
-  /^strapi-plugin-/i,
+  /^strapi-plugin-react-/i,
   ''
 );
 


### PR DESCRIPTION
This fixes 2 issues
- The `pluginId` in server API is `editorjs` only but in admin it's recognized as `react-editorjs` so it causes some issues with upload and link preview as [43](https://github.com/melishev/strapi-plugin-react-editorjs/issues/43), [38](https://github.com/melishev/strapi-plugin-react-editorjs/issues/38), [36](https://github.com/melishev/strapi-plugin-react-editorjs/issues/36)
- The user token could be retrieved from sessionStorage or localStorage (see `auth.getToken` from [@strapi/helper-plugin](https://www.npmjs.com/package/@strapi/helper-plugin)) (depends on user browser?) that also causes the bug [36](https://github.com/melishev/strapi-plugin-react-editorjs/issues/36)