### PR TITLE
Fix LinkTool to link

### DIFF
--- a/admin/src/config/customTools.js
+++ b/admin/src/config/customTools.js
@@ -33,7 +33,7 @@ const customTools = {
     },
   },
   code: Code,
-  LinkTool: {
+  link: {
     class: LinkTool,
     config: {
       endpoint: `/api/${PluginId}/link`,


### PR DESCRIPTION
Just for consistency on the LinkTool property name compares to other types

before
```
{
	"id": "V3lqp78HNu",
	"type": "LinkTool",
	"data": ...
},
{
	"id": "hG7KrynPBP",
	"type": "raw",
	"data": ...
},
{
	"id": "WXeqvxSfeh",
	"type": "quote",
	"data": ...
},
```
after
```
{
	"id": "V3lqp78HNu",
	"type": "link",
	"data": ...
},
{
	"id": "hG7KrynPBP",
	"type": "raw",
	"data": ...
},
{
	"id": "WXeqvxSfeh",
	"type": "quote",
	"data": ...
},
```