### PR TITLE
hotfix: empty editor and required field fix when onChange event is triggered

### DIFF
--- a/admin/src/components/editorjs/index.js
+++ b/admin/src/components/editorjs/index.js
@@ -51,8 +51,11 @@ const Editor = ({ onChange, name, value }) => {
             document.querySelector('[data-tool="image"]').remove()
           }}
           onChange={(api, newData) => {
-            if (newData.blocks.length) {
-              onChange({target: {name, value: JSON.stringify(newData)}});
+            if (!newData.blocks.length) {
+              newData = null;
+              onChange({ target: { name, value: newData } });
+            } else {
+              onChange({ target: { name, value: JSON.stringify(newData) } });
             }
           }}
           tools={{...requiredTools, ...customTools, ...customImageTool}}


### PR DESCRIPTION
 `onChange` event was not triggering when the editor was empty. 

To solve this problem I changed the `newData.blocks.length `condition to `!newData.blocks.length`

If condition is met, `newData` is made `null`.

I returned the newData unchanged in cases where this condition is not met.

So now we can trigger the `onChange` event when the editor is empty.

The `newData = null `statement can also provide control when text input is required.

